### PR TITLE
Fixed 'return' indentation error

### DIFF
--- a/source/timestepping.py
+++ b/source/timestepping.py
@@ -19,5 +19,4 @@ def timeloop(method, rhs, Y0, dt, tmax, **kwargs):
         t += dt
         soln = np.vstack((soln, Ynp1))
         times.append(t)
-
     return times, soln


### PR DESCRIPTION
Fixed 'return' indentation error in 2nd function of timestepping.py